### PR TITLE
Audit Tests and Fixes

### DIFF
--- a/offchain/shared/index.ts
+++ b/offchain/shared/index.ts
@@ -5,12 +5,26 @@ import {
   VendorConfiguration,
   VendorVendorSpend,
 } from "../types/contracts";
-import { Slot, Value } from "@blaze-cardano/core";
+import {
+  Address,
+  RewardAccount,
+  Slot,
+  Value,
+  type CredentialCore,
+} from "@blaze-cardano/core";
+
+export interface CompiledScript<T, C> {
+  config: C;
+  script: T;
+  credential: CredentialCore;
+  rewardAccount?: RewardAccount;
+  scriptAddress: Address;
+}
 
 export function loadTreasuryScript(
   network: Core.NetworkId,
   config: TreasuryConfiguration,
-) {
+): CompiledScript<TreasuryTreasuryWithdraw, TreasuryConfiguration> {
   const script = new TreasuryTreasuryWithdraw(config);
   const credential = {
     type: Core.CredentialType.ScriptHash,
@@ -23,6 +37,7 @@ export function loadTreasuryScript(
     paymentPart: credential,
   });
   return {
+    config,
     script,
     credential,
     rewardAccount,
@@ -33,7 +48,7 @@ export function loadTreasuryScript(
 export function loadVendorScript(
   network: Core.NetworkId,
   config: VendorConfiguration,
-) {
+): CompiledScript<VendorVendorSpend, VendorConfiguration> {
   const script = new VendorVendorSpend(config);
   const credential = {
     type: Core.CredentialType.ScriptHash,
@@ -45,17 +60,26 @@ export function loadVendorScript(
     paymentPart: credential,
   });
   return {
+    config,
     script,
     credential,
     scriptAddress,
   };
 }
 
+export interface CompiledScripts {
+  treasuryScript: CompiledScript<
+    TreasuryTreasuryWithdraw,
+    TreasuryConfiguration
+  >;
+  vendorScript: CompiledScript<VendorVendorSpend, VendorConfiguration>;
+}
+
 export function loadScripts(
   network: Core.NetworkId,
   treasuryConfig: TreasuryConfiguration,
   vendorConfig: VendorConfiguration,
-) {
+): CompiledScripts {
   const treasuryScript = loadTreasuryScript(network, treasuryConfig);
   const vendorScript = loadVendorScript(network, vendorConfig);
   return {

--- a/offchain/tests/findings/txpipe.test.ts
+++ b/offchain/tests/findings/txpipe.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, test } from "bun:test";
+import { Core, makeValue } from "@blaze-cardano/sdk";
+import * as Data from "@blaze-cardano/data";
+import { Emulator } from "@blaze-cardano/emulator";
+import {
+  deployScripts,
+  sampleTreasuryConfig,
+  sampleVendorConfig,
+  setupEmulator,
+  treasuryOutput,
+} from "../utilities.test";
+import {
+  loadScripts,
+  loadTreasuryScript,
+  unix_to_slot,
+  type CompiledScript,
+} from "../../shared";
+import { sweep } from "../../treasury/sweep";
+import {
+  TreasuryConfiguration,
+  TreasurySpendRedeemer,
+  TreasuryTreasuryWithdraw,
+} from "../../types/contracts";
+import { Address, Script } from "@blaze-cardano/core";
+
+describe("TxPipe Audit Findings", () => {
+  let emulator: Emulator;
+  let config: TreasuryConfiguration;
+  beforeEach(async () => {
+    emulator = await setupEmulator(undefined, false);
+  });
+
+  describe("TRC-001", () => {
+    describe("anyone", () => {
+      test("cannot sweep multiple treasury scripts and steal ADA", async () => {
+        const scripts_1 = loadScripts(
+          Core.NetworkId.Testnet,
+          await sampleTreasuryConfig(emulator, 1),
+          await sampleVendorConfig(emulator, 1),
+        );
+        await deployScripts(emulator, scripts_1);
+        const scripts_2 = loadScripts(
+          Core.NetworkId.Testnet,
+          await sampleTreasuryConfig(emulator, 2),
+          await sampleVendorConfig(emulator, 2),
+        );
+        await deployScripts(emulator, scripts_2);
+
+        const refInput_1 = emulator.lookupScript(
+          scripts_1.treasuryScript.script.Script,
+        );
+        const refInput_2 = emulator.lookupScript(
+          scripts_2.treasuryScript.script.Script,
+        );
+
+        const amount = 100_000_000n;
+        const inputA = treasuryOutput(
+          emulator,
+          scripts_1.treasuryScript,
+          makeValue(amount),
+          Data.Void(),
+        );
+        const inputB = treasuryOutput(
+          emulator,
+          scripts_2.treasuryScript,
+          makeValue(amount),
+          Data.Void(),
+        );
+
+        const future = scripts_1.treasuryScript.config.expiration * 2n;
+        emulator.stepForwardToSlot(future);
+
+        await emulator.as("Anyone", async (blaze, address) => {
+          await emulator.expectScriptFailure(
+            blaze
+              .newTransaction()
+              .addInput(
+                inputA,
+                Data.serialize(TreasurySpendRedeemer, "SweepTreasury"),
+              )
+              .addInput(
+                inputB,
+                Data.serialize(TreasurySpendRedeemer, "SweepTreasury"),
+              )
+              .setValidFrom(unix_to_slot(future))
+              .addReferenceInput(refInput_1)
+              .addReferenceInput(refInput_2)
+              .setDonation(amount)
+              .payLovelace(address, amount),
+            /adsfadsf/,
+          );
+        });
+      });
+    });
+  });
+});

--- a/offchain/tests/treasury/fund.test.ts
+++ b/offchain/tests/treasury/fund.test.ts
@@ -65,7 +65,7 @@ describe("When funding", () => {
       vendorConfig,
     );
     configs = { treasury: treasuryConfig, vendor: vendorConfig };
-    rewardAccount = treasuryScriptManifest.rewardAccount;
+    rewardAccount = treasuryScriptManifest.rewardAccount!;
     treasuryScript = treasuryScriptManifest.script;
     vendorScript = vendorScriptManifest.script;
     treasuryScriptAddress = treasuryScriptManifest.scriptAddress;

--- a/offchain/tests/utilities.test.ts
+++ b/offchain/tests/utilities.test.ts
@@ -306,12 +306,9 @@ export async function deployScripts(
   await emulator.publishScript(vendorScript.script.Script);
 }
 
-export function treasuryOutput(
+export function scriptOutput<T, C>(
   emulator: Emulator,
-  treasuryScript: CompiledScript<
-    TreasuryTreasuryWithdraw,
-    TreasuryConfiguration
-  >,
+  treasuryScript: CompiledScript<T, C>,
   value: Core.Value,
   datum?: PlutusData,
 ) {


### PR DESCRIPTION
This branch collects a series of tests for the findings uncovered as part of the two independent audits.

Each separate commit introduces a test for the finding; and a future commit fixes one or more of these issues.

# TxPipe Findings

## TRS-001 - Double Satisfaction with multiple Treasury Scripts

Test added: [Commit 0f5b332](https://github.com/SundaeSwap-finance/treasury-contracts/commit/f369abe06b0486f7cd894784182cbd4774f5c2fd)
Fix added:

## TRS-002 - Treasury Script Withdrawal Satisfaction

(Note: awaiting clarification / reclassification)

Test added:
Fix added:

## TRS-101 - Possible to fund malformed vendor UTxOs

Test added: [Commit f369abe](https://github.com/SundaeSwap-finance/treasury-contracts/commit/dc72cd1ec2f1b0b03e7c817ecdf187f818abec45)
Fix added:

## TRS-102 - Valid Range manipulation

Test added: [Commit 3229949](https://github.com/SundaeSwap-finance/treasury-contracts/commit/3229949a1968e19b21de0a922e53d59fa9023b48)
Fix added:

## TRS-103 - Modification of later vendor payouts

(n.b. accidentally committed TRS-103 and TRS-104 in the same commit)

Test added: [Commit bb5ad58](https://github.com/SundaeSwap-finance/treasury-contracts/commit/bb5ad584cb725c7de9bc543f0f8d581972fef763)
Fix added:

## TRS-104 - Treasury Fund Double Satisfaction

Test added: [Commit bb5ad58](https://github.com/SundaeSwap-finance/treasury-contracts/commit/bb5ad584cb725c7de9bc543f0f8d581972fef763)
Fix added:

## TRS-105 - Malformed vendor UTxOs can be stolen

(n.b. commit message is wrong)

Test added: [Commit 505f4fa](https://github.com/SundaeSwap-finance/treasury-contracts/commit/505f4faaa27496c69e1c5ac800ab6ead16624a2f)

## TRS-201 - Vendor Sweep can't be used with Reorganize

Test added: N/A (this isn't possible to test, as it's just a code cleanliness issue)
Fix added:

## TRS-202 - Can attach a stake credential to matured funds when sweeping

Test added: [Commit 2abede7](https://github.com/SundaeSwap-finance/treasury-contracts/commit/2abede75b0b76cbf5ca4a48db887576057863850)
Fix added:

## TRS-203 - Treasury sweep vulnerable to DDOS

Test added: [Commit b0985da](https://github.com/SundaeSwap-finance/treasury-contracts/commit/b0985dafff1200623b929202cb527cfbda1d78ea)
Fix added:


# MLabs Findings

(Awaiting draft report)