### PR TITLE
Cli optional fields and metadatum fixes

### DIFF
--- a/offchain/cli/shared.ts
+++ b/offchain/cli/shared.ts
@@ -908,7 +908,7 @@ export function metaDataToConfig(
       ),
     },
     expiration: BigInt(metadata.body.expiration),
-    payout_upperbound: BigInt(metadata.body.payoutUpperbound),
+    payout_upperbound: BigInt(metadata.body.payoutUpperbound ?? 0),
   };
   const vendorConfig: VendorConfiguration = {
     registry_token: metadata.instance,
@@ -926,7 +926,7 @@ export function metaDataToConfig(
         metadata.body.permissions,
       ),
     },
-    expiration: BigInt(metadata.body.vendorExpiration),
+    expiration: BigInt(metadata.body.vendorExpiration ?? 0),
   };
   return { treasuryConfig, vendorConfig };
 }
@@ -1273,7 +1273,7 @@ export async function getTransactionMetadata<MetadataBody>(
     hashAlgorithm: "blake2b-256",
     body: body,
     instance,
-    txAuthor: await input({
+    txAuthor: await maybeInput({
       message:
         "Enter a hexidecimal pubkey hash, or a bech32 encoded address for the author of this transaction",
       validate: (s) => isAddressOrHex(s, CredentialType.KeyHash),

--- a/offchain/cli/treasury/publish.ts
+++ b/offchain/cli/treasury/publish.ts
@@ -116,7 +116,7 @@ export async function publish(): Promise<void> {
 
         const auxData = new AuxiliaryData();
         auxData.setMetadata(toTxMetadata(metadata!));
-        const tx = await blazeInstance
+        let tx = await blazeInstance
           .newTransaction()
           .addInput(bootstrapUtxoObj[0])
           .addOutput(oneshotOutput)
@@ -126,9 +126,14 @@ export async function publish(): Promise<void> {
             Void(),
           )
           .setAuxiliaryData(auxData)
-          .provideScript(oneshotScript.Script)
-          .addRequiredSigner(Ed25519KeyHashHex(metadata!.txAuthor))
-          .complete();
+          .provideScript(oneshotScript.Script);
+
+        if (metadata.txAuthor) {
+          tx = await tx.addRequiredSigner(Ed25519KeyHashHex(metadata!.txAuthor));
+        }
+
+        tx = await tx.complete();
+
         await transactionDialog(
           blazeInstance.provider.network,
           tx.toCbor().toString(),

--- a/offchain/src/metadata/shared.ts
+++ b/offchain/src/metadata/shared.ts
@@ -113,7 +113,7 @@ export async function fromTxMetadata(
 
 export function toTxMetadata(m: ITransactionMetadata): Metadata {
   const root = new MetadatumMap();
-  root.insert(Metadatum.newText("@context"), Metadatum.newText(m["@context"]));
+  root.insert(Metadatum.newText("@context"), toMetadatum(m["@context"]));
   root.insert(
     Metadatum.newText("hashAlgorithm"),
     Metadatum.newText(m.hashAlgorithm),

--- a/offchain/src/metadata/shared.ts
+++ b/offchain/src/metadata/shared.ts
@@ -35,7 +35,7 @@ export interface ITransactionMetadata<B = TMetadataBody> {
   hashAlgorithm: "blake2b-256";
   body: B;
   comment?: string;
-  txAuthor: string;
+  txAuthor?: string;
   instance: string;
 }
 
@@ -118,7 +118,9 @@ export function toTxMetadata(m: ITransactionMetadata): Metadata {
     Metadatum.newText("hashAlgorithm"),
     Metadatum.newText(m.hashAlgorithm),
   );
-  root.insert(Metadatum.newText("txAuthor"), Metadatum.newText(m.txAuthor));
+  if ("txAuthor" in m && m.txAuthor) {
+    root.insert(Metadatum.newText("txAuthor"), Metadatum.newText(m.txAuthor));
+  }
   root.insert(Metadatum.newText("instance"), Metadatum.newText(m.instance));
   if ("comment" in m && m.comment) {
     const comment = toMetadatum(m.comment);

--- a/offchain/src/metadata/types/new-instance.ts
+++ b/offchain/src/metadata/types/new-instance.ts
@@ -7,8 +7,8 @@ export interface INewInstance extends IMetadataBodyBase {
   label?: string;
   description?: string;
   expiration: bigint;
-  payoutUpperbound: bigint;
-  vendorExpiration: bigint;
+  payoutUpperbound?: bigint;
+  vendorExpiration?: bigint;
   permissions: Record<
     TPermissionName,
     TPermissionMetadata | TPermissionName | null


### PR DESCRIPTION
- :round_pushpin: **Allow some metadata fields to be optional.**
    This doesn't change how the metadata is generated, but allows some modified metadata to still be parsed and processed correctly. This enables people like me not interested in the 'vendor' parts to just get rid of the irrelevant information from the metadata by just editing the generated file manually.

- :round_pushpin: **Fix '@context' value to CBOR transformation.**
    When the context URI is longer than 64 UTF-8 bytes, this produces otherwise an invalid encoding.
