### PR TITLE
chore: update withdraw milestone types

### DIFF
--- a/offchain/cli/vendor/withdraw.ts
+++ b/offchain/cli/vendor/withdraw.ts
@@ -3,7 +3,6 @@ import * as Data from "@blaze-cardano/data";
 import { Blaze, Provider, Wallet } from "@blaze-cardano/sdk";
 import { input } from "@inquirer/prompts";
 import {
-  getAnchor,
   getBlazeInstance,
   getConfigs,
   getSigners,
@@ -14,26 +13,7 @@ import {
 import { Vendor } from "src";
 import { VendorDatum } from "src/generated-types/contracts";
 import { toPermission } from "src/metadata/types/permission";
-import {
-  IAnchorWithLabel,
-  IMilestone,
-  IWithdraw,
-} from "src/metadata/types/withdraw";
-
-async function getEvidence(): Promise<IAnchorWithLabel[]> {
-  const evidence: IAnchorWithLabel[] = [];
-  while (true) {
-    const label = await input({
-      message: "Enter the label for the evidence (or leave empty to finish):",
-    });
-    if (!label) {
-      break;
-    }
-    const anchor = await getAnchor();
-    evidence.push({ label, ...anchor });
-  }
-  return evidence;
-}
+import { IMilestone, IWithdraw } from "src/metadata/types/withdraw";
 
 async function getFinishedMilestones(
   vendorInputs: TransactionUnspentOutput[],
@@ -66,10 +46,9 @@ async function getFinishedMilestones(
       break;
     }
     const milestone = {
-      description: await input({
+      comment: await input({
         message: `Enter the description for milestone ${identifier}:`,
       }),
-      evidence: await getEvidence(),
     } as IMilestone;
     milestones[identifier] = milestone;
   }

--- a/offchain/package.json
+++ b/offchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sundaeswap/treasury-funds",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "license": "MIT",
   "main": "./dist/cjs/index.js",

--- a/offchain/src/metadata/context.jsonld
+++ b/offchain/src/metadata/context.jsonld
@@ -27,14 +27,17 @@
             "signature": {
               "@id": "tom:signaturePermission",
               "@context": {
-             	"keyHash": "tom:keyHashSignaturePermission"
+                "keyHash": "tom:keyHashSignaturePermission"
               }
             },
-            "scripts": { "@id": "tom:scripts", "@container": "@list" },
+            "scripts": {
+              "@id": "tom:scripts",
+              "@container": "@list"
+            },
             "atLeast": {
               "@id": "tom:atLeastPermission",
               "@context": {
-  	        "required": "tom:requiredAtLeastPermission"
+                "required": "tom:requiredAtLeastPermission"
               }
             },
             "allOf": "tom:allOfPermission",
@@ -62,10 +65,7 @@
           "@container": "@index",
           "@context": {
             "acceptanceCriteria": "tom:acceptanceCriteria",
-            "evidence": {
-              "@id": "tom:evidence",
-              "@container": "@list"
-            },
+            "comment": "tom:comment",
             "reason": "tom:pauseReason",
             "resolution": "tom:pauseResolution"
           }

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -248,7 +248,7 @@ Funds may be withdrawn from the vendor contract. In such cases, the metadata wil
     "event": "withdraw"
     "milestones": {
       "001": {
-        "description": "long-form markdown annotated description"
+        "comment": "long-form markdown annotated comment (can be blank)"
       }
     }
   }

--- a/offchain/src/metadata/types/withdraw.ts
+++ b/offchain/src/metadata/types/withdraw.ts
@@ -1,13 +1,8 @@
-import { IAnchor, IMetadataBodyBase } from "../shared.js";
+import { IMetadataBodyBase } from "../shared.js";
 import { ETransactionEvent } from "./events.js";
 
-export interface IAnchorWithLabel extends IAnchor {
-  label: string;
-}
-
 export interface IMilestone {
-  description: string;
-  evidence: IAnchorWithLabel[];
+  comment: string;
 }
 
 export interface IWithdraw extends IMetadataBodyBase {


### PR DESCRIPTION
Removes `evidence` from the `milestones` type when withdrawing vendor milestones.