### PR TITLE
Change Disburse metadata standard

### DIFF
--- a/offchain/cli/treasury/disburse.ts
+++ b/offchain/cli/treasury/disburse.ts
@@ -1,15 +1,12 @@
 import {
   Address,
   Ed25519KeyHashHex,
-  Ed25519PublicKey,
-  Ed25519PublicKeyHex,
   TransactionId,
-  TransactionInput,
+  TransactionInput
 } from "@blaze-cardano/core";
 import { Blaze, makeValue, Provider, Wallet } from "@blaze-cardano/sdk";
 import { getBlazeInstance, getConfigs, transactionDialog } from "cli/shared";
 import { Treasury } from "src";
-import * as Data from "@blaze-cardano/data";
 
 export async function disburse(
   blazeInstance: Blaze<Provider, Wallet> | undefined = undefined,

--- a/offchain/src/metadata/context.jsonld
+++ b/offchain/src/metadata/context.jsonld
@@ -79,10 +79,6 @@
         },
         "justification": "tom:justification",
         "destination": "tom:destination",
-        "additionalDestinations": {
-          "@id": "tom:additionalDestinations",
-          "@container": "@set"
-        },
         "estimatedReturn": "tom:estimatedReturn"
       }
     }

--- a/offchain/src/metadata/context.jsonld
+++ b/offchain/src/metadata/context.jsonld
@@ -78,8 +78,9 @@
           }
         },
         "justification": "tom:justification",
-        "destination": {
-          "@id": "tom:destination",
+        "destination": "tom:destination",
+        "additionalDestinations": {
+          "@id": "tom:additionalDestinations",
           "@container": "@set"
         },
         "estimatedReturn": "tom:estimatedReturn"

--- a/offchain/src/metadata/context.jsonld
+++ b/offchain/src/metadata/context.jsonld
@@ -78,7 +78,10 @@
           }
         },
         "justification": "tom:justification",
-        "destination": "tom:destination",
+        "destination": {
+          "@id": "tom:destination",
+          "@container": "@set"
+        },
         "estimatedReturn": "tom:estimatedReturn"
       }
     }

--- a/offchain/src/metadata/shared.ts
+++ b/offchain/src/metadata/shared.ts
@@ -8,6 +8,7 @@ import { decodeFirst } from "cbor";
 
 import { IPause, IResume } from "./types/adjudicate.js";
 import { IComplete } from "./types/complete.js";
+import { IDisburse } from "./types/disburse.js";
 import { ETransactionEvent } from "./types/events.js";
 import { IFund } from "./types/fund.js";
 import { IInitialize } from "./types/initialize-reorganize.js";
@@ -30,7 +31,8 @@ export type TMetadataBody =
   | IInitialize
   | IWithdraw
   | IComplete
-  | INewInstance;
+  | INewInstance
+  | IDisburse;
 
 export interface ITransactionMetadata<B = TMetadataBody> {
   "@context": string;

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -174,7 +174,7 @@ Finally, each milestone itself **may** have a human readable label, description,
 
 # Disburse
 
-A disburse transaction with a single destination will have the following metadata attached to it:
+A disburse transaction with will have the following metadata attached to it:
 
 ```json
 {
@@ -203,7 +203,7 @@ A disburse transaction with a single destination will have the following metadat
 The description describes mechanically **what** is intended to happen with the funds (such as “swapping for a USD to mint USDM”).
 The justification defines **why** the oversight committee believes this falls within its remit as administrator of the treasury funds (“Vendor X cannot be paid in crypto”).
 The destination gives a human readable label for the destination, which can be aggregated across transactions (“NBX Exchange Account”)
-Destination can be a single object or a set of objects (destinations).
+Destination may be encoded either as a single object or as an array of objects. Producers of metadata should prefer the array form, to ensure backwards compatibility consumers must accept either.
 The estimatedReturn, if provided, gives an estimate, as a POSIX timestamp, of when the funds are expected to be returned to the treasury contract.
 
 # Complete

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -187,7 +187,7 @@ A disburse transaction will have the following metadata attached to it:
     "label": "Human Readable Title",
     "description": "long-form markdown annotated description",
     "justification": "long-form markdown justification",
-    "destination": [
+    "destination": 
       {
         "label": "Coinbase",
         "details": {
@@ -195,6 +195,7 @@ A disburse transaction will have the following metadata attached to it:
           "anchorDataHash": "..."
         }
       },
+    "additionalDestinations": [
       {
         "label": "Kraken",
         "details": {
@@ -211,6 +212,7 @@ A disburse transaction will have the following metadata attached to it:
 The description describes mechanically **what** is intended to happen with the funds (such as “swapping for a USD to mint USDM”).
 The justification defines **why** the oversight committee believes this falls within its remit as administrator of the treasury funds (“Vendor X cannot be paid in crypto”).
 The destination gives a human readable label for the destination, which can be aggregated across transactions (“NBX Exchange Account”).
+The additionalDestinations allows the author to add more destinations
 The estimatedReturn, if provided, gives an estimate, as a POSIX timestamp, of when the funds are expected to be returned to the treasury contract.
 
 # Complete

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -187,17 +187,23 @@ A disburse transaction will have the following metadata attached to it:
     "label": "Human Readable Title",
     "description": "long-form markdown annotated description",
     "justification": "long-form markdown justification",
-    "destinations": {
-      "0": {
+    "destination": [
+      {
         "label": "Coinbase",
-        "amount": 1234,
-        "estimatedReturn": 12345,
+        "details": {
+          "anchorUrl": "ipfs://...",
+          "anchorDataHash": "..."
+        }
+      },
+      {
+        "label": "Kraken",
         "details": {
           "anchorUrl": "ipfs://...",
           "anchorDataHash": "..."
         }
       }
-    }
+    ],
+    "estimatedReturn": 1234
   }
 }
 ```

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -174,7 +174,7 @@ Finally, each milestone itself **may** have a human readable label, description,
 
 # Disburse
 
-A disburse transaction will have the following metadata attached to it:
+A disburse transaction with a single destination will have the following metadata attached to it:
 
 ```json
 {
@@ -195,15 +195,6 @@ A disburse transaction will have the following metadata attached to it:
           "anchorDataHash": "..."
         }
       },
-    "additionalDestinations": [
-      {
-        "label": "Kraken",
-        "details": {
-          "anchorUrl": "ipfs://...",
-          "anchorDataHash": "..."
-        }
-      }
-    ],
     "estimatedReturn": 1234
   }
 }
@@ -211,8 +202,8 @@ A disburse transaction will have the following metadata attached to it:
 
 The description describes mechanically **what** is intended to happen with the funds (such as “swapping for a USD to mint USDM”).
 The justification defines **why** the oversight committee believes this falls within its remit as administrator of the treasury funds (“Vendor X cannot be paid in crypto”).
-The destination gives a human readable label for the destination, which can be aggregated across transactions (“NBX Exchange Account”).
-The additionalDestinations allows the author to add more destinations for funds.
+The destination gives a human readable label for the destination, which can be aggregated across transactions (“NBX Exchange Account”)
+Destination can be a single object or a set of objects (destinations).
 The estimatedReturn, if provided, gives an estimate, as a POSIX timestamp, of when the funds are expected to be returned to the treasury contract.
 
 # Complete

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -212,7 +212,7 @@ A disburse transaction will have the following metadata attached to it:
 The description describes mechanically **what** is intended to happen with the funds (such as “swapping for a USD to mint USDM”).
 The justification defines **why** the oversight committee believes this falls within its remit as administrator of the treasury funds (“Vendor X cannot be paid in crypto”).
 The destination gives a human readable label for the destination, which can be aggregated across transactions (“NBX Exchange Account”).
-The additionalDestinations allows the author to add more destinations
+The additionalDestinations allows the author to add more destinations for funds.
 The estimatedReturn, if provided, gives an estimate, as a POSIX timestamp, of when the funds are expected to be returned to the treasury contract.
 
 # Complete

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -187,14 +187,13 @@ A disburse transaction with will have the following metadata attached to it:
     "label": "Human Readable Title",
     "description": "long-form markdown annotated description",
     "justification": "long-form markdown justification",
-    "destination": 
-      {
-        "label": "Coinbase",
-        "details": {
-          "anchorUrl": "ipfs://...",
-          "anchorDataHash": "..."
-        }
-      },
+    "destination": {
+      "label": "Coinbase",
+      "details": {
+        "anchorUrl": "ipfs://...",
+        "anchorDataHash": "..."
+      }
+    },
     "estimatedReturn": 1234
   }
 }

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -183,18 +183,21 @@ A disburse transaction will have the following metadata attached to it:
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "disburse"
+    "event": "disburse",
     "label": "Human Readable Title",
     "description": "long-form markdown annotated description",
     "justification": "long-form markdown justification",
-    "destination": {
-      "label": "Coinbase",
-      "details": {
-        "anchorUrl": "ipfs://...",
-        "anchorDataHash": "..."
+    "destinations": {
+      "0": {
+        "label": "Coinbase",
+        "amount": 1234,
+        "estimatedReturn": 12345,
+        "details": {
+          "anchorUrl": "ipfs://...",
+          "anchorDataHash": "..."
+        }
       }
-    },
-    "estimatedReturn": 1234
+    }
   }
 }
 ```

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -107,8 +107,8 @@ In each of these transactions, the following metadata will be attached:
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "initialize | reorganize"
-    "reason": "human readable justification for this reorganize; optional in the case of withdraw"
+    "event": "initialize | reorganize",
+    "reason": "human readable justification for this reorganize; optional in the case of withdraw",
     "outputs": {
       0: { "identifier": "...", "label": "..." }
     }
@@ -133,7 +133,7 @@ When we pay funds out of the treasury smart contract, into the vendor contract, 
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "fund"
+    "event": "fund",
     "identifier": "PO123",
     "otherIdentifiers": [...],
     "label": "Human Readable Title",
@@ -218,7 +218,7 @@ The vendor contract can be spent to “withdraw” funds, and withdraw zero fund
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "complete"
+    "event": "complete",
     "milestones": {
       "001": {
         "description": "long-form markdown annotated description",
@@ -252,7 +252,7 @@ Funds may be withdrawn from the vendor contract. In such cases, the metadata wil
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "withdraw"
+    "event": "withdraw",
     "milestones": {
       "001": {
         "comment": "long-form markdown annotated comment (can be blank)"
@@ -297,7 +297,7 @@ After resolving the issue with a milestone, the oversight committee can resume t
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "resume"
+    "event": "resume",
       "milestones": {
       "001": {
         "reason": "long-form markdown annotated description"
@@ -318,7 +318,7 @@ In rare cases, the vendor and the oversight committee both agree to modify a pro
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "modify"
+    "event": "modify",
     "identifier": "PO123",
     "otherIdentifiers": [...],
     "label": "Human Readable Title",
@@ -357,7 +357,7 @@ As a special case, the project may be completely cancelled and refunded to the t
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "cancel"
+    "event": "cancel",
     "reason": "long-form reason for the cancellation",
   }
 }
@@ -374,7 +374,7 @@ Finally, at the end of the lifecycle of funds, any surplus may be swept back to 
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "sweep"
+    "event": "sweep",
     "comment": "a long form comment on why funds are being swept now",
   }
 }

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -107,8 +107,8 @@ In each of these transactions, the following metadata will be attached:
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "initialize | reorganize",
-    "reason": "human readable justification for this reorganize; optional in the case of withdraw",
+    "event": "initialize | reorganize"
+    "reason": "human readable justification for this reorganize; optional in the case of withdraw"
     "outputs": {
       0: { "identifier": "...", "label": "..." }
     }
@@ -133,7 +133,7 @@ When we pay funds out of the treasury smart contract, into the vendor contract, 
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "fund",
+    "event": "fund"
     "identifier": "PO123",
     "otherIdentifiers": [...],
     "label": "Human Readable Title",
@@ -218,7 +218,7 @@ The vendor contract can be spent to “withdraw” funds, and withdraw zero fund
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "complete",
+    "event": "complete"
     "milestones": {
       "001": {
         "description": "long-form markdown annotated description",
@@ -252,7 +252,7 @@ Funds may be withdrawn from the vendor contract. In such cases, the metadata wil
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "withdraw",
+    "event": "withdraw"
     "milestones": {
       "001": {
         "comment": "long-form markdown annotated comment (can be blank)"
@@ -297,7 +297,7 @@ After resolving the issue with a milestone, the oversight committee can resume t
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "resume",
+    "event": "resume"
       "milestones": {
       "001": {
         "reason": "long-form markdown annotated description"
@@ -318,7 +318,7 @@ In rare cases, the vendor and the oversight committee both agree to modify a pro
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "modify",
+    "event": "modify"
     "identifier": "PO123",
     "otherIdentifiers": [...],
     "label": "Human Readable Title",
@@ -357,7 +357,7 @@ As a special case, the project may be completely cancelled and refunded to the t
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "cancel",
+    "event": "cancel"
     "reason": "long-form reason for the cancellation",
   }
 }
@@ -374,7 +374,7 @@ Finally, at the end of the lifecycle of funds, any surplus may be swept back to 
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "sweep",
+    "event": "sweep"
     "comment": "a long form comment on why funds are being swept now",
   }
 }

--- a/offchain/src/metadata/types/disburse.ts
+++ b/offchain/src/metadata/types/disburse.ts
@@ -12,5 +12,5 @@ export interface IDisburse extends IMetadataBodyBase {
   description: string;
   justification: string;
   destination: IDestination | IDestination[];
-  estimatedReturn: bigint;
+  estimatedReturn?: bigint;
 }

--- a/offchain/src/metadata/types/disburse.ts
+++ b/offchain/src/metadata/types/disburse.ts
@@ -1,0 +1,17 @@
+import { IAnchor, IMetadataBodyBase } from "../shared.js";
+import { ETransactionEvent } from "./events.js";
+
+export interface IDestination {
+  label: string;
+  details?: IAnchor;
+}
+
+export interface IDisburse extends IMetadataBodyBase {
+  event: ETransactionEvent.DISBURSE;
+  label: string;
+  description: string;
+  justification: string;
+  destination: IDestination;
+  additionalDestinations?: IDestination[];
+  estimatedReturn?: bigint;
+}

--- a/offchain/src/metadata/types/disburse.ts
+++ b/offchain/src/metadata/types/disburse.ts
@@ -11,7 +11,6 @@ export interface IDisburse extends IMetadataBodyBase {
   label: string;
   description: string;
   justification: string;
-  destination: IDestination;
-  additionalDestinations?: IDestination[];
-  estimatedReturn?: bigint;
+  destination: IDestination | IDestination[];
+  estimatedReturn: bigint;
 }

--- a/offchain/src/metadata/types/events.ts
+++ b/offchain/src/metadata/types/events.ts
@@ -7,4 +7,5 @@ export enum ETransactionEvent {
   REORGANIZE = "reorganize",
   PUBLISH = "publish",
   WITHDRAW = "withdraw",
+  DISBURSE = "disburse",
 }

--- a/offchain/src/metadata/types/index.ts
+++ b/offchain/src/metadata/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./adjudicate.js";
 export * from "./complete.js";
+export * from "./disburse.js";
 export * from "./events.js";
 export * from "./fund.js";
 export * from "./initialize-reorganize.js";


### PR DESCRIPTION
### What?

- Allowed `destination` field within Disburse metadata to represent both a single or multiple destinations

### Why?

The current disburse metadata does not allow multiple destinations.

Intersect plans to disburse a single project's funds to two different destinations.
This is for the USDA and USDM pilot for the Tweag proposal.

By adding a new optional field, we maintain backwards compatibility, in a reasonable way.

This could be done across two different transactions with the current specification
but for transparency it might be nicer to have it in one transaction.