### PR TITLE
Add fund metadata for proposal group key and allowlist.

### DIFF
--- a/offchain/CHANGELOG.md
+++ b/offchain/CHANGELOG.md
@@ -2,17 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.26](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.25...v0.0.26) (2026-05-20)
+
+### Features
+
+- add `proposalGroupKey` to fund transaction metadata for linking projects under the same governance proposal ([92a6cfa](https://github.com/SundaeSwap-finance/treasury-contracts/commit/92a6cfaf2f03d07db610b00569eba484a4ec6347))
+- add `allowlist` to fund metadata (`scriptHash` and payout destinations, with optional labels)
+- extend fund CLI to prompt for proposal group key, allowlist addresses, and optional address labels
+- document fund metadata fields in `spec.md` and `context.jsonld`
+- export `ITransactionMetadata` from the package entrypoint
+- add metadata round-trip test for `proposalGroupKey` and `allowlist`
+
 ### [0.0.11](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.10...v0.0.11) (2025-06-16)
 
 ### [0.0.10](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.9...v0.0.10) (2025-06-15)
 
 ### [0.0.9](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.8...v0.0.9) (2025-06-14)
 
-
 ### Bug Fixes
 
-* export ([55c3e93](https://github.com/SundaeSwap-finance/treasury-contracts/commit/55c3e93a4c6477fe54fb324c1c23d2c1c67b3bbc))
-* test ([263d762](https://github.com/SundaeSwap-finance/treasury-contracts/commit/263d762f76dadda82d5e1b1f83ff561c8921e3b6))
+- export ([55c3e93](https://github.com/SundaeSwap-finance/treasury-contracts/commit/55c3e93a4c6477fe54fb324c1c23d2c1c67b3bbc))
+- test ([263d762](https://github.com/SundaeSwap-finance/treasury-contracts/commit/263d762f76dadda82d5e1b1f83ff561c8921e3b6))
 
 ### [0.0.8](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.7...v0.0.8) (2025-06-14)
 
@@ -20,32 +30,28 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### [0.0.6](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.5...v0.0.6) (2025-06-14)
 
-
 ### Bug Fixes
 
-* relative urls in file ([c996213](https://github.com/SundaeSwap-finance/treasury-contracts/commit/c9962133d94815e2480419608b8cef5cc3eae49a))
-* unused var ([9205c1b](https://github.com/SundaeSwap-finance/treasury-contracts/commit/9205c1b54c3912e7d304b0ec8fbe42d82e777702))
+- relative urls in file ([c996213](https://github.com/SundaeSwap-finance/treasury-contracts/commit/c9962133d94815e2480419608b8cef5cc3eae49a))
+- unused var ([9205c1b](https://github.com/SundaeSwap-finance/treasury-contracts/commit/9205c1b54c3912e7d304b0ec8fbe42d82e777702))
 
 ### [0.0.5](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.4...v0.0.5) (2025-06-14)
 
-
 ### Bug Fixes
 
-* auto imports ([9d8057c](https://github.com/SundaeSwap-finance/treasury-contracts/commit/9d8057cea872981105754306fb6a0b035da87fa6))
+- auto imports ([9d8057c](https://github.com/SundaeSwap-finance/treasury-contracts/commit/9d8057cea872981105754306fb6a0b035da87fa6))
 
 ### [0.0.4](https://github.com/SundaeSwap-finance/treasury-contracts/compare/v0.0.3...v0.0.4) (2025-06-12)
 
 ### 0.0.3 (2025-06-11)
 
-
 ### Features
 
-* mvp for cli to publish registry hash ([915dff7](https://github.com/SundaeSwap-finance/treasury-contracts/commit/915dff7bce25b560a85e651d7fdf03a24f311e64))
-
+- mvp for cli to publish registry hash ([915dff7](https://github.com/SundaeSwap-finance/treasury-contracts/commit/915dff7bce25b560a85e651d7fdf03a24f311e64))
 
 ### Bug Fixes
 
-* vscode setting json ([26f0ca1](https://github.com/SundaeSwap-finance/treasury-contracts/commit/26f0ca1d81916ced742f86098c285099ee09a32b))
+- vscode setting json ([26f0ca1](https://github.com/SundaeSwap-finance/treasury-contracts/commit/26f0ca1d81916ced742f86098c285099ee09a32b))
 
 ### 0.0.2 (2025-05-23)
 

--- a/offchain/cli/treasury/fund.ts
+++ b/offchain/cli/treasury/fund.ts
@@ -4,7 +4,11 @@ import { confirm, input, select } from "@inquirer/prompts";
 
 import { Void } from "@blaze-cardano/data";
 import { Treasury } from "../../src";
-import { IFund, IFundMilestone } from "../../src/metadata/types/fund";
+import {
+  IFund,
+  IFundAllowlist,
+  IFundMilestone,
+} from "../../src/metadata/types/fund";
 import {
   toMultisig,
   toPermission,
@@ -117,6 +121,7 @@ export async function fund(
   )) as TPermissionMetadata;
 
   let allowListScript: Script | undefined;
+  let fundAllowlistMetadata: IFundAllowlist | undefined;
 
   if (
     await confirm({
@@ -124,6 +129,7 @@ export async function fund(
     })
   ) {
     const addresses = [];
+    const allowlistDestinations: IFundAllowlist["addresses"] = [];
     while (true) {
       const nextAddress = await input({
         message: "Enter an address, empty to finish",
@@ -136,6 +142,12 @@ export async function fund(
           console.log("No addresses provided");
         }
       }
+      const label = await maybeInput({
+        message: "Human-readable label for this address? (optional)",
+      });
+      allowlistDestinations.push(
+        label ? { address: nextAddress, label } : { address: nextAddress },
+      );
       addresses.push(
         coreAddressToContractsAddress(Address.fromBech32(nextAddress)),
       );
@@ -145,6 +157,10 @@ export async function fund(
       addresses,
     });
     allowListScript = allowlist.script.Script;
+    fundAllowlistMetadata = {
+      scriptHash: allowlist.script.Script.hash(),
+      addresses: allowlistDestinations,
+    };
 
     vendorPermissions = {
       allOf: {
@@ -193,6 +209,9 @@ export async function fund(
     identifier: await input({
       message: "What is the main identifier for this project?",
     }),
+    proposalGroupKey: await maybeInput({
+      message: "What is the proposal group key for this fund? (optional)",
+    }),
     otherIdentifiers: await getIdentifiers(),
     label: await input({
       message: "What is the name of this project?",
@@ -223,6 +242,9 @@ export async function fund(
   const { schedule, milestones } = await getMilestones();
 
   metadataBody.milestones = milestones;
+  if (fundAllowlistMetadata) {
+    metadataBody.allowlist = fundAllowlistMetadata;
+  }
 
   const txMetadata = await getTransactionMetadata(
     configs.treasury.registry_token,

--- a/offchain/package.json
+++ b/offchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sundaeswap/treasury-funds",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "license": "MIT",
   "main": "./dist/cjs/index.js",

--- a/offchain/src/index.ts
+++ b/offchain/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./generated-types/contracts.js";
 export * as Contracts from "./generated-types/contracts.js";
 export * as Metadata from "./metadata/shared.js";
+export type { ITransactionMetadata } from "./metadata/shared.js";
 export * from "./metadata/types/index.js";
 export * as Utils from "./shared/index.js";
 export * as Treasury from "./treasury/index.js";

--- a/offchain/src/metadata/context.jsonld
+++ b/offchain/src/metadata/context.jsonld
@@ -65,8 +65,23 @@
           "@id": "tom:outputs",
           "@container": "@index"
         },
+        "proposalGroupKey": "tom:proposalGroupKey",
         "vendor": "tom:vendor",
         "contract": "tom:contract",
+        "allowlist": {
+          "@id": "tom:allowlist",
+          "@context": {
+            "scriptHash": "tom:allowlistScriptHash",
+            "addresses": {
+              "@id": "tom:allowlistAddresses",
+              "@container": "@list",
+              "@context": {
+                "address": "tom:allowlistAddress",
+                "label": "tom:allowlistLabel"
+              }
+            }
+          }
+        },
         "milestones": {
           "@id": "tom:milestones",
           "@container": "@index",

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -133,8 +133,9 @@ When we pay funds out of the treasury smart contract, into the vendor contract, 
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "fund"
+    "event": "fund",
     "identifier": "PO123",
+    "proposalGroupKey": "ekklesia-proposal-42",
     "otherIdentifiers": [...],
     "label": "Human Readable Title",
     "description": "long-form markdown annotated description",
@@ -149,20 +150,29 @@ When we pay funds out of the treasury smart contract, into the vendor contract, 
       "anchorUrl": "ipfs://...",
       "anchorDataHash": "...",
     },
-    "milestones": {
-      "001": {
+    "milestones": [
+      {
         "identifier": "001",
         "label": "...",
         "description": "A human readable description",
         "acceptanceCriteria": "...",
         "details": { ... }
       }
+    ],
+    "allowlist": {
+      "scriptHash": "ab12cd34...",
+      "addresses": [
+        { "address": "addr_test1...", "label": "Wallet A" },
+        { "address": "addr_test1..." }
+      ]
     }
   }
 }
 ```
 
 The project is assigned a unique identifier, which will be inherited by all descendants of the relevant UTxO. This can be, for example, an internal project number. In some cases, there **may** be other related project numbers (for example: the vendors internal project number, or the Ekklesia identifier for the project), which can be provided in otherIdentifiers.
+
+**proposalGroupKey** optionally links multiple funded projects that belong to the same governance proposal. When unused, producers should omit the field or set it to an empty string.
 
 The project itself is given a human readable label that serves as a title, as well as a long-form, markdown formatted description.
 
@@ -171,6 +181,8 @@ The vendor is assigned a label, and **may** link to additional details about the
 If available, a link to the contract can be provided. This could be hosted on a durable storage solution like IPFS or Iagon storage, or on more conventional hosting platforms. It also **may** be publicly visible, or encrypted for certain parties if necessary. These are considered concerns outside the scope of the TOM portal.
 
 Finally, each milestone itself **may** have a human readable label, description, acceptance criteria, and reference to further details via an anchor URL. The milestones are indexed by their identifier, to match other metadata messages, and must match 1:1 with the milestones in the transaction datum.
+
+When the vendor is gated by a parameterised allowlist script, **allowlist** records the script hash and the ordered payout destinations (bech32 addresses, with optional human-readable labels). This block is attached at funding time so transaction review and indexers can display destinations without re-deriving them from script bytes.
 
 # Disburse
 

--- a/offchain/src/metadata/types/fund.ts
+++ b/offchain/src/metadata/types/fund.ts
@@ -14,13 +14,26 @@ export interface IFundMilestone {
   details?: IAnchor;
 }
 
+/** Funding-time allowlist destinations attached to fund transaction metadata. */
+export interface IFundAllowlistDestination {
+  address: string;
+  label?: string;
+}
+
+export interface IFundAllowlist {
+  scriptHash: string;
+  addresses: IFundAllowlistDestination[];
+}
+
 export interface IFund extends IMetadataBodyBase {
   event: ETransactionEvent.FUND;
   identifier: string;
+  proposalGroupKey?: string;
   otherIdentifiers: string[];
   label: string;
   description: string;
   vendor: IVendor;
   contract?: IAnchor;
   milestones: IFundMilestone[];
+  allowlist?: IFundAllowlist;
 }

--- a/offchain/tests/metadata/index.test.ts
+++ b/offchain/tests/metadata/index.test.ts
@@ -7,6 +7,8 @@ import {
   toTxMetadata,
 } from "../../src/metadata/shared.js";
 import { ETransactionEvent } from "../../src/metadata/types/events.js";
+import { IFund } from "../../src/metadata/types/fund.js";
+import { INewInstance } from "../../src/metadata/types/new-instance.js";
 
 const publishMetadata: ITransactionMetadata = {
   body: {
@@ -16,7 +18,7 @@ const publishMetadata: ITransactionMetadata = {
       outputIndex: 1n,
       transactionId:
         "bee1ae94e4ab00990cb15ea38b141a3335f36dacc0d5642224be5dfa40a1b4dd",
-    },
+    } as unknown as INewInstance["seedUtxo"],
     expiration: 1767243600000n,
     description: "Testing new indexing code!",
     permissions: {
@@ -42,7 +44,7 @@ const publishMetadata: ITransactionMetadata = {
   hashAlgorithm: "blake2b-256",
 };
 
-const fundMetadata: ITransactionMetadata = {
+const fundMetadata: ITransactionMetadata<IFund> = {
   body: {
     event: ETransactionEvent.FUND,
     label: "Sample Instance 12",
@@ -105,5 +107,46 @@ describe("fromMetadata", () => {
     );
     const result2 = await fromTxMetadata(metadata2);
     expect(result2).toMatchObject(fundMetadata);
+  });
+
+  it("should round-trip fund metadata with proposalGroupKey and allowlist", async () => {
+    const metadata: ITransactionMetadata<IFund> = {
+      ...fundMetadata,
+      body: {
+        ...fundMetadata.body,
+        proposalGroupKey: "proposal-alpha",
+        allowlist: {
+          scriptHash: "ab12cd34".repeat(7),
+          addresses: [
+            {
+              address: "addr_test1qqqqexample1qqqqexample1qqqqexample1qqqqex",
+              label: "Wallet A",
+            },
+            {
+              address: "addr_test1qqqqexample2qqqqexample2qqqqexample2qqqqex",
+            },
+          ],
+        },
+      },
+    };
+
+    const encoded = toTxMetadata(metadata);
+    const decoded = await fromTxMetadata(encoded);
+    expect(decoded.body).toMatchObject({
+      event: ETransactionEvent.FUND,
+      proposalGroupKey: "proposal-alpha",
+      allowlist: {
+        scriptHash: "ab12cd34".repeat(7),
+        addresses: [
+          {
+            address: "addr_test1qqqqexample1qqqqexample1qqqqexample1qqqqex",
+            label: "Wallet A",
+          },
+          {
+            address: "addr_test1qqqqexample2qqqqexample2qqqqexample2qqqqex",
+          },
+        ],
+      },
+    });
   });
 });


### PR DESCRIPTION
# Fund metadata: proposal group key and allowlist

## Summary

Extends **fund** transaction metadata (and the interactive fund CLI) so funded projects can be linked to a governance proposal group and, when using a parameterised allowlist vendor script, record payout destinations on-chain metadata for review and indexing.

Bumps `@sundaeswap/treasury-funds` to **0.0.26**.

## Motivation

- **Governance:** Multiple treasury-funded projects may belong to the same proposal; indexers and UIs need a stable cross-project key (`proposalGroupKey`).
- **Allowlist transparency:** When vendor payouts are gated by an allowlist script, reviewers should see the script hash and destination addresses in CIP-100-style metadata without decoding script parameters.

## Changes

### Metadata schema (`offchain/src/metadata`)

| Area | Change |
|------|--------|
| `types/fund.ts` | `proposalGroupKey?`, `IFundAllowlist` / `IFundAllowlistDestination`, optional `allowlist` on `IFund` |
| `context.jsonld` | JSON-LD mappings for `proposalGroupKey` and `allowlist` |
| `spec.md` | Document new fields; align fund `milestones` example with array shape |

### CLI (`offchain/cli/treasury/fund.ts`)

- Optional prompt for **proposal group key**
- When allowlist is enabled:
  - Collect payout addresses (bech32, key-hash payment credentials)
  - Optional **human-readable label** per address
  - Attach `allowlist` block to fund metadata (`scriptHash` + `addresses`)
- Existing flow unchanged when allowlist is not used

### Package

- Export `ITransactionMetadata` from `offchain/src/index.ts`
- `package.json` → `0.0.26`
- `CHANGELOG.md` → release notes for 0.0.26