### PR TITLE
Fix offchain npm publish authentication

### DIFF
--- a/.github/workflows/offchain.yml
+++ b/.github/workflows/offchain.yml
@@ -61,9 +61,6 @@ jobs:
       #     git pull --rebase --no-verify origin main
       #     git push --follow-tags --no-verify origin main
 
-      - name: Configure npm authentication
-        run: npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
-
       - id: check
         name: Check published version
         uses: EndBug/version-check@v2
@@ -75,6 +72,8 @@ jobs:
       # Create Release, if the version has changed
       - name: Publish
         if: steps.check.outputs.changed == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_NPM_TOKEN }}
         run: |
           cd offchain
           npm publish


### PR DESCRIPTION
## Summary
- Remove the deprecated `npm config set` step that used `NPM_TOKEN`.
- Authenticate the publish step with `NODE_AUTH_TOKEN` from `PUBLISH_NPM_TOKEN` after npm key rotation.

## Test plan
- [ ] Confirm `PUBLISH_NPM_TOKEN` is configured in GitHub Actions secrets.
- [ ] Merge and re-run the offchain workflow on `main` (or merge after `0.0.26` publish is still pending).
- [ ] Verify the Publish job completes without 403/404 on `npm publish`.