### PR TITLE
Unify script reference attachment in offchain SDK (v0.0.27)

### DIFF
--- a/offchain/package.json
+++ b/offchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sundaeswap/treasury-funds",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "license": "MIT",
   "main": "./dist/cjs/index.js",

--- a/offchain/src/shared/index.ts
+++ b/offchain/src/shared/index.ts
@@ -14,6 +14,7 @@ import {
   Core,
   makeValue,
   Provider,
+  TxBuilder,
   Wallet,
 } from "@blaze-cardano/sdk";
 import { type Cardano } from "@cardano-sdk/core";
@@ -321,4 +322,24 @@ export function rewardAccountFromScript(
     hash: script.hash(),
   };
   return RewardAccount.fromCredential(credential, network);
+}
+
+/**
+ * Prefer the registry script reference UTxO already attached in configsOrScripts,
+ * then fall back to resolveScriptRef (burn address) and inline provideScript.
+ */
+export async function attachScriptRef<P extends Provider, W extends Wallet>(
+  tx: TxBuilder,
+  compiledScript: ICompiledScript<{ Script: Script }, unknown>,
+  blaze: Blaze<P, W>,
+) {
+  if (!compiledScript.scriptRef) {
+    compiledScript.scriptRef = await blaze.provider.resolveScriptRef(
+      compiledScript.script.Script,
+    );
+  }
+  if (compiledScript.scriptRef) {
+    return tx.addReferenceInput(compiledScript.scriptRef);
+  }
+  return tx.provideScript(compiledScript.script.Script);
 }

--- a/offchain/src/treasury/disburse/index.ts
+++ b/offchain/src/treasury/disburse/index.ts
@@ -21,6 +21,7 @@ import * as Tx from "@blaze-cardano/tx";
 
 import { TreasurySpendRedeemer } from "../../generated-types/contracts.js";
 import {
+  attachScriptRef,
   coreValueToContractsValue,
   loadConfigsAndScripts,
   rewardAccountFromScript,
@@ -52,27 +53,24 @@ export async function disburse<P extends Provider, W extends Wallet>({
 }: IDisburseArgs<P, W>): Promise<TxBuilder> {
   console.log("Disburse transaction started");
   const { configs, scripts } = loadConfigsAndScripts(blaze, configsOrScripts);
-  const { script: treasuryScript, scriptAddress: treasuryScriptAddress } =
-    scripts.treasuryScript;
+  const { scriptAddress: treasuryScriptAddress } = scripts.treasuryScript;
   const registryInput = await blaze.provider.getUnspentOutputByNFT(
     AssetId(configs.treasury.registry_token + toHex(Buffer.from("REGISTRY"))),
   );
 
-  const refInput = await blaze.provider.resolveScriptRef(
-    treasuryScript.Script.hash(),
-  );
-  if (!refInput)
-    throw new Error("Could not find treasury script reference on-chain");
-  let tx = blaze
-    .newTransaction()
-    .addReferenceInput(registryInput)
-    .addReferenceInput(refInput);
+  let tx = blaze.newTransaction().addReferenceInput(registryInput);
+  tx = await attachScriptRef(tx, scripts.treasuryScript, blaze);
 
   if (!!additionalScripts) {
     for (const { script, redeemer } of additionalScripts) {
       const refInput = await blaze.provider.resolveScriptRef(script);
+      if (!refInput) {
+        throw new Error(
+          `Could not find one of the additional scripts provided on-chain: ${script.hash()}. Please publish the script and try again.`,
+        );
+      }
       tx = tx
-        .addReferenceInput(refInput!)
+        .addReferenceInput(refInput)
         .addWithdrawal(
           rewardAccountFromScript(script, blaze.provider.network),
           0n,

--- a/offchain/src/treasury/fund/index.ts
+++ b/offchain/src/treasury/fund/index.ts
@@ -29,6 +29,7 @@ import {
 import { ITransactionMetadata, toTxMetadata } from "../../metadata/shared.js";
 import { IFund } from "../../metadata/types/fund.js";
 import {
+  attachScriptRef,
   coreValueToContractsValue,
   loadConfigsAndScripts,
   rewardAccountFromScript,
@@ -109,16 +110,7 @@ export async function fund<P extends Provider, W extends Wallet>({
     }
   }
 
-  if (!scripts.treasuryScript.scriptRef) {
-    scripts.treasuryScript.scriptRef = await blaze.provider.resolveScriptRef(
-      scripts.treasuryScript.script.Script,
-    );
-  }
-  if (scripts.treasuryScript.scriptRef) {
-    tx.addReferenceInput(scripts.treasuryScript.scriptRef);
-  } else {
-    tx.provideScript(scripts.treasuryScript.script.Script);
-  }
+  await attachScriptRef(tx, scripts.treasuryScript, blaze);
 
   if (metadata) {
     const auxData = new AuxiliaryData();

--- a/offchain/src/treasury/reorganize/index.ts
+++ b/offchain/src/treasury/reorganize/index.ts
@@ -18,6 +18,7 @@ import {
 
 import { TreasurySpendRedeemer } from "../../generated-types/contracts.js";
 import {
+  attachScriptRef,
   loadConfigsAndScripts,
   rewardAccountFromScript,
   TConfigsOrScripts,
@@ -41,24 +42,26 @@ export async function reorganize<P extends Provider, W extends Wallet>({
   additionalScripts,
 }: IReorganizeArgs<P, W>): Promise<TxBuilder> {
   const { configs, scripts } = loadConfigsAndScripts(blaze, configsOrScripts);
-  const { script, scriptAddress } = scripts.treasuryScript;
+  const { scriptAddress } = scripts.treasuryScript;
   const registryInput = await blaze.provider.getUnspentOutputByNFT(
     AssetId(configs.treasury.registry_token + toHex(Buffer.from("REGISTRY"))),
   );
-  const refInput = await blaze.provider.resolveScriptRef(script.Script.hash());
-  if (!refInput)
-    throw new Error("Could not find treasury script reference on-chain");
   let tx = blaze
     .newTransaction()
     .setValidUntil(Slot(Number(configs.treasury.expiration / 1000n) - 1))
-    .addReferenceInput(registryInput)
-    .addReferenceInput(refInput);
+    .addReferenceInput(registryInput);
+  tx = await attachScriptRef(tx, scripts.treasuryScript, blaze);
 
   if (!!additionalScripts) {
     for (const { script, redeemer } of additionalScripts) {
       const refInput = await blaze.provider.resolveScriptRef(script);
+      if (!refInput) {
+        throw new Error(
+          `Could not find one of the additional scripts provided on-chain: ${script.hash()}. Please publish the script and try again.`,
+        );
+      }
       tx = tx
-        .addReferenceInput(refInput!)
+        .addReferenceInput(refInput)
         .addWithdrawal(
           rewardAccountFromScript(script, blaze.provider.network),
           0n,

--- a/offchain/src/treasury/sweep/index.ts
+++ b/offchain/src/treasury/sweep/index.ts
@@ -11,6 +11,7 @@ import {
 
 import { TreasurySpendRedeemer } from "../../generated-types/contracts.js";
 import {
+  attachScriptRef,
   loadConfigsAndScripts,
   TConfigsOrScripts,
 } from "../../shared/index.js";
@@ -30,22 +31,19 @@ export async function sweep<P extends Provider, W extends Wallet>({
 }: ISweepArgs<P, W>): Promise<TxBuilder> {
   const { configs, scripts } = loadConfigsAndScripts(blaze, configsOrScripts);
   amount ??= input.output().amount().coin();
-  const { script, scriptAddress } = scripts.treasuryScript;
+  const { scriptAddress } = scripts.treasuryScript;
   const registryInput = await blaze.provider.getUnspentOutputByNFT(
     AssetId(configs.treasury.registry_token + toHex(Buffer.from("REGISTRY"))),
   );
-  const refInput = await blaze.provider.resolveScriptRef(script.Script.hash());
-  if (!refInput)
-    throw new Error("Could not find treasury script reference on-chain");
   let tx = blaze
     .newTransaction()
     .addInput(input, Data.serialize(TreasurySpendRedeemer, "SweepTreasury"))
     .setValidFrom(
       blaze.provider.unixToSlot(Number(configs.treasury.expiration + 1000n)),
     )
-    .addReferenceInput(registryInput)
-    .addReferenceInput(refInput)
-    .setDonation(amount);
+    .addReferenceInput(registryInput);
+  tx = await attachScriptRef(tx, scripts.treasuryScript, blaze);
+  tx = tx.setDonation(amount);
 
   const remainder = Value.merge(input.output().amount(), makeValue(-amount));
   if (remainder !== Value.zero()) {

--- a/offchain/src/treasury/sweep/index.ts
+++ b/offchain/src/treasury/sweep/index.ts
@@ -41,9 +41,9 @@ export async function sweep<P extends Provider, W extends Wallet>({
     .setValidFrom(
       blaze.provider.unixToSlot(Number(configs.treasury.expiration + 1000n)),
     )
-    .addReferenceInput(registryInput);
+    .addReferenceInput(registryInput)
+    .setDonation(amount);
   tx = await attachScriptRef(tx, scripts.treasuryScript, blaze);
-  tx = tx.setDonation(amount);
 
   const remainder = Value.merge(input.output().amount(), makeValue(-amount));
   if (remainder !== Value.zero()) {

--- a/offchain/src/treasury/withdraw/index.ts
+++ b/offchain/src/treasury/withdraw/index.ts
@@ -15,6 +15,7 @@ import {
 import { ITransactionMetadata, toTxMetadata } from "../../metadata/shared.js";
 import { IInitialize } from "../../metadata/types/initialize-reorganize.js";
 import {
+  attachScriptRef,
   loadConfigsAndScripts,
   TConfigsOrScripts,
 } from "../../shared/index.js";
@@ -35,13 +36,10 @@ export async function withdraw<P extends Provider, W extends Wallet>({
   withdrawAmount = undefined,
 }: IWithdrawArgs<P, W>): Promise<TxBuilder> {
   const { configs, scripts } = loadConfigsAndScripts(blaze, configsOrScripts);
-  const { script, rewardAccount, scriptAddress } = scripts.treasuryScript;
+  const { rewardAccount, scriptAddress } = scripts.treasuryScript;
   const registryInput = await blaze.provider.getUnspentOutputByNFT(
     AssetId(configs.treasury.registry_token + toHex(Buffer.from("REGISTRY"))),
   );
-  const refInput = await blaze.provider.resolveScriptRef(script.Script.hash());
-  if (!refInput)
-    throw new Error("Could not find treasury script reference on-chain");
 
   const amount = amounts.reduce((acc, val) => acc + val, BigInt(0));
 
@@ -52,8 +50,8 @@ export async function withdraw<P extends Provider, W extends Wallet>({
       withdrawAmount !== undefined ? withdrawAmount : amount,
       Data.Void(),
     )
-    .addReferenceInput(refInput)
     .addReferenceInput(registryInput);
+  txBuilder = await attachScriptRef(txBuilder, scripts.treasuryScript, blaze);
 
   if (metadata) {
     if (amounts.length !== Object.keys(metadata.body.outputs).length)

--- a/offchain/src/vendor/adjudicate/index.ts
+++ b/offchain/src/vendor/adjudicate/index.ts
@@ -28,6 +28,7 @@ import {
 } from "../../metadata/shared.js";
 import type { IPause, IResume } from "../../metadata/types/adjudicate.js";
 import {
+  attachScriptRef,
   loadConfigsAndScripts,
   rewardAccountFromScript,
   TConfigsOrScripts,
@@ -114,16 +115,7 @@ export async function adjudicate<P extends Provider, W extends Wallet>({
     }
   }
 
-  if (!scripts.vendorScript.scriptRef) {
-    scripts.vendorScript.scriptRef = await blaze.provider.resolveScriptRef(
-      scripts.vendorScript.script.Script,
-    );
-  }
-  if (scripts.vendorScript.scriptRef) {
-    tx.addReferenceInput(scripts.vendorScript.scriptRef);
-  } else {
-    tx.provideScript(scripts.vendorScript.script.Script);
-  }
+  await attachScriptRef(tx, scripts.vendorScript, blaze);
 
   if (metadata) {
     const auxData = new AuxiliaryData();

--- a/offchain/src/vendor/malformed/index.ts
+++ b/offchain/src/vendor/malformed/index.ts
@@ -10,6 +10,7 @@ import {
 
 import { VendorSpendRedeemer } from "../../generated-types/contracts.js";
 import {
+  attachScriptRef,
   loadConfigsAndScripts,
   TConfigsOrScripts,
 } from "../../shared/index.js";
@@ -32,17 +33,7 @@ export async function sweep_malformed<P extends Provider, W extends Wallet>({
   );
 
   let tx = blaze.newTransaction().addReferenceInput(registryInput);
-
-  if (!scripts.vendorScript.scriptRef) {
-    scripts.vendorScript.scriptRef = await blaze.provider.resolveScriptRef(
-      scripts.vendorScript.script.Script,
-    );
-  }
-  if (scripts.vendorScript.scriptRef) {
-    tx.addReferenceInput(scripts.vendorScript.scriptRef);
-  } else {
-    tx.provideScript(scripts.vendorScript.script.Script);
-  }
+  tx = await attachScriptRef(tx, scripts.vendorScript, blaze);
 
   let value = Value.zero();
   for (const input of inputs) {

--- a/offchain/src/vendor/modify/index.ts
+++ b/offchain/src/vendor/modify/index.ts
@@ -20,6 +20,7 @@ import {
   VendorSpendRedeemer,
 } from "../../generated-types/contracts.js";
 import {
+  attachScriptRef,
   contractsValueToCoreValue,
   loadConfigsAndScripts,
   rewardAccountFromScript,
@@ -47,32 +48,31 @@ export async function modify<P extends Provider, W extends Wallet>({
 }: IModifyArgs<P, W>): Promise<TxBuilder> {
   const { configs, scripts } = loadConfigsAndScripts(blaze, configsOrScripts);
   const { scriptAddress: treasuryScriptAddress } = scripts.treasuryScript;
-  const { scriptAddress: vendorScriptAddress, script: vendorScript } =
-    scripts.vendorScript;
+  const { scriptAddress: vendorScriptAddress } = scripts.vendorScript;
   const registryInput = await blaze.provider.getUnspentOutputByNFT(
     AssetId(configs.vendor.registry_token + toHex(Buffer.from("REGISTRY"))),
   );
-  const refInput = await blaze.provider.resolveScriptRef(
-    vendorScript.Script.hash(),
-  );
-  if (!refInput)
-    throw new Error("Could not find vendor script reference on-chain");
   const thirty_six_hours = 36 * 60 * 60 * 1000; // 36 hours in milliseconds
   let tx = blaze
     .newTransaction()
     .addReferenceInput(registryInput)
-    .addReferenceInput(refInput)
     .setValidFrom(blaze.provider.unixToSlot(now.valueOf()))
     .setValidUntil(blaze.provider.unixToSlot(now.valueOf() + thirty_six_hours))
     .addInput(input, Data.serialize(VendorSpendRedeemer, "Modify"));
+  tx = await attachScriptRef(tx, scripts.vendorScript, blaze);
   for (const signer of signers) {
     tx = tx.addRequiredSigner(signer);
   }
   if (!!additionalScripts) {
     for (const { script, redeemer } of additionalScripts) {
       const refInput = await blaze.provider.resolveScriptRef(script);
+      if (!refInput) {
+        throw new Error(
+          `Could not find one of the additional scripts provided on-chain: ${script.hash()}. Please publish the script and try again.`,
+        );
+      }
       tx = tx
-        .addReferenceInput(refInput!)
+        .addReferenceInput(refInput)
         .addWithdrawal(
           rewardAccountFromScript(script, blaze.provider.network),
           0n,
@@ -131,17 +131,7 @@ export async function cancel<P extends Provider, W extends Wallet>({
     .setValidFrom(blaze.provider.unixToSlot(now.valueOf()))
     .setValidUntil(blaze.provider.unixToSlot(now.valueOf() + thirty_six_hours))
     .addInput(input, Data.serialize(VendorSpendRedeemer, "Modify"));
-
-  if (!scripts.vendorScript.scriptRef) {
-    scripts.vendorScript.scriptRef = await blaze.provider.resolveScriptRef(
-      scripts.vendorScript.script.Script,
-    );
-  }
-  if (scripts.vendorScript.scriptRef) {
-    tx.addReferenceInput(scripts.vendorScript.scriptRef);
-  } else {
-    tx.provideScript(scripts.vendorScript.script.Script);
-  }
+  tx = await attachScriptRef(tx, scripts.vendorScript, blaze);
 
   for (const signer of signers) {
     tx = tx.addRequiredSigner(signer);

--- a/offchain/src/vendor/sweep/index.ts
+++ b/offchain/src/vendor/sweep/index.ts
@@ -13,6 +13,7 @@ import {
   VendorSpendRedeemer,
 } from "../../generated-types/contracts.js";
 import {
+  attachScriptRef,
   contractsValueToCoreValue,
   loadConfigsAndScripts,
   TConfigsOrScripts,
@@ -43,17 +44,7 @@ export async function sweep<P extends Provider, W extends Wallet>({
     .addReferenceInput(registryInput)
     .setValidFrom(blaze.provider.unixToSlot(now.valueOf()))
     .setValidUntil(blaze.provider.unixToSlot(now.valueOf() + thirtSixHours));
-
-  if (!scripts.vendorScript.scriptRef) {
-    scripts.vendorScript.scriptRef = await blaze.provider.resolveScriptRef(
-      scripts.vendorScript.script.Script,
-    );
-  }
-  if (scripts.vendorScript.scriptRef) {
-    tx.addReferenceInput(scripts.vendorScript.scriptRef);
-  } else {
-    tx.provideScript(scripts.vendorScript.script.Script);
-  }
+  tx = await attachScriptRef(tx, scripts.vendorScript, blaze);
 
   let value = Value.zero();
   for (const input of inputs) {

--- a/offchain/src/vendor/withdraw/index.ts
+++ b/offchain/src/vendor/withdraw/index.ts
@@ -27,6 +27,7 @@ import { ITransactionMetadata, toTxMetadata } from "../../metadata/shared.js";
 import { IComplete } from "../../metadata/types/complete.js";
 import { IWithdraw } from "../../metadata/types/withdraw.js";
 import {
+  attachScriptRef,
   contractsValueToCoreValue,
   loadConfigsAndScripts,
   rewardAccountFromScript,
@@ -90,16 +91,7 @@ export async function withdraw<P extends Provider, W extends Wallet>({
     }
   }
 
-  if (!scripts.vendorScript.scriptRef) {
-    scripts.vendorScript.scriptRef = await blaze.provider.resolveScriptRef(
-      scripts.vendorScript.script.Script,
-    );
-  }
-  if (scripts.vendorScript.scriptRef) {
-    tx.addReferenceInput(scripts.vendorScript.scriptRef);
-  } else {
-    tx.provideScript(scripts.vendorScript.script.Script);
-  }
+  await attachScriptRef(tx, scripts.vendorScript, blaze);
 
   if (metadata) {
     const auxData = new AuxiliaryData();

--- a/offchain/tests/treasury/disburse.test.ts
+++ b/offchain/tests/treasury/disburse.test.ts
@@ -16,7 +16,9 @@ import {
   type TreasuryTreasuryWithdraw,
 } from "../../src/generated-types/contracts";
 import {
+  constructScripts,
   loadTreasuryScript,
+  loadVendorScript,
   coreValueToContractsValue as translateValue,
 } from "../../src/shared";
 import { disburse } from "../../src/treasury/disburse";
@@ -129,6 +131,47 @@ describe("When disbursing", () => {
             blaze,
             await disburse({
               configsOrScripts: { configs },
+              blaze,
+              input: scriptInput,
+              recipient: vendor,
+              amount: makeValue(10_000_000n),
+              signers: [Ed25519KeyHashHex(await disburse_key(emulator))],
+            }),
+          );
+        });
+      });
+      test("can disburse by providing the treasury script ref manually", async () => {
+        await emulator.as(Disburser, async (blaze) => {
+          const vendor = await emulator.register("Vendor");
+          const vendorScript = loadVendorScript(
+            Core.NetworkId.Testnet,
+            configs.vendor,
+            true,
+          );
+          const scripts = constructScripts(
+            Core.NetworkId.Testnet,
+            configs.treasury,
+            treasuryScript.Script,
+            configs.vendor,
+            vendorScript.script.Script,
+            Core.TransactionUnspentOutput.fromCore([
+              {
+                index: 9,
+                txId: Core.TransactionId("0".repeat(64)),
+              },
+              {
+                address: Core.PaymentAddress(
+                  "addr_test1wza7ec20249sqg87yu2aqkqp735qa02q6yd93u28gzul93gvc4wuw",
+                ),
+                value: new Core.Value(5000001n).toCore(),
+                scriptReference: treasuryScript.Script.asPlutusV3()?.toCore(),
+              },
+            ]),
+          );
+          await emulator.expectValidTransaction(
+            blaze,
+            await disburse({
+              configsOrScripts: { configs, scripts },
               blaze,
               input: scriptInput,
               recipient: vendor,


### PR DESCRIPTION
## Summary
- Add shared `attachScriptRef` helper that prefers an explicit `scriptRef`, resolves on-chain via burn address, and falls back to inline `provideScript`.
- Apply the helper across all treasury and vendor transaction builders (disburse, fund, reorganize, sweep, withdraw, modify, adjudicate, malformed).
- Add explicit null-check errors for `additionalScripts` that were previously using unsafe non-null assertions.
- Bump `@sundaeswap/treasury-funds` to `0.0.27`.

## Test plan
- [x] `bun run types`
- [x] `bun test` (161 tests pass)
- [x] New test: disburse with manually provided treasury `scriptRef`