### PR TITLE
Feat: enhance sweep metadata spec

### DIFF
--- a/offchain/src/metadata/context.jsonld
+++ b/offchain/src/metadata/context.jsonld
@@ -66,6 +66,7 @@
           "@container": "@index"
         },
         "proposalGroupKey": "tom:proposalGroupKey",
+        "projectIdentifier": "tom:projectIdentifier",
         "vendor": "tom:vendor",
         "contract": "tom:contract",
         "allowlist": {

--- a/offchain/src/metadata/shared.ts
+++ b/offchain/src/metadata/shared.ts
@@ -13,6 +13,7 @@ import { ETransactionEvent } from "./types/events.js";
 import { IFund } from "./types/fund.js";
 import { IInitialize } from "./types/initialize-reorganize.js";
 import { INewInstance } from "./types/new-instance.js";
+import { ISweep } from "./types/sweep.js";
 import { IWithdraw } from "./types/withdraw.js";
 
 export interface IAnchor {
@@ -32,7 +33,8 @@ export type TMetadataBody =
   | IWithdraw
   | IComplete
   | INewInstance
-  | IDisburse;
+  | IDisburse
+  | ISweep;
 
 export interface ITransactionMetadata<B = TMetadataBody> {
   "@context": string;

--- a/offchain/src/metadata/spec.md
+++ b/offchain/src/metadata/spec.md
@@ -384,8 +384,14 @@ Finally, at the end of the lifecycle of funds, any surplus may be swept back to 
   "txAuthor": "c27...",
   "instance": "1ef...",
   "body": {
-    "event": "sweep"
-    "comment": "a long form comment on why funds are being swept now",
+    "event": "sweep",
+    "projectIdentifier": "PO123",
+    "milestones": ["001", "002"],
+    "comment": "a long form comment on why funds are being swept now"
   }
 }
 ```
+
+When the swept surplus relates to a funded project (for example, a sweep from the vendor contract, or of treasury funds that were earmarked for a project), projectIdentifier references the identifier assigned to the project in the fund event, and milestones lists the identifiers of the milestones from that fund event that the surplus originated from. Both are omitted when there is no associated project.
+
+The comment provides a long-form markdown justification for why the funds are being swept now. All fields besides event are optional.

--- a/offchain/src/metadata/types/events.ts
+++ b/offchain/src/metadata/types/events.ts
@@ -8,4 +8,5 @@ export enum ETransactionEvent {
   PUBLISH = "publish",
   WITHDRAW = "withdraw",
   DISBURSE = "disburse",
+  SWEEP = "sweep",
 }

--- a/offchain/src/metadata/types/index.ts
+++ b/offchain/src/metadata/types/index.ts
@@ -6,4 +6,5 @@ export * from "./fund.js";
 export * from "./initialize-reorganize.js";
 export * from "./new-instance.js";
 export * from "./permission.js";
+export * from "./sweep.js";
 export * from "./withdraw.js";

--- a/offchain/src/metadata/types/sweep.ts
+++ b/offchain/src/metadata/types/sweep.ts
@@ -3,5 +3,10 @@ import { ETransactionEvent } from "./events.js";
 
 export interface ISweep extends IMetadataBodyBase {
   event: ETransactionEvent.SWEEP;
+  // The identifier assigned to the funded project in the fund event, when the
+  // swept surplus relates to one
+  projectIdentifier?: string;
+  // The fund event's milestone identifiers the surplus originated from
+  milestones?: string[];
   comment?: string;
 }

--- a/offchain/src/metadata/types/sweep.ts
+++ b/offchain/src/metadata/types/sweep.ts
@@ -1,0 +1,7 @@
+import { IMetadataBodyBase } from "../shared.js";
+import { ETransactionEvent } from "./events.js";
+
+export interface ISweep extends IMetadataBodyBase {
+  event: ETransactionEvent.SWEEP;
+  comment?: string;
+}


### PR DESCRIPTION
add optional fields `projectIdentifier` and `milestones` to sweep metadata spec
to allow for round trip tracking of funds returned for specific projects and milestones